### PR TITLE
Some CFIR Clean-up/removal + Fixing the handling of ConstantInt

### DIFF
--- a/MergeTool.cpp
+++ b/MergeTool.cpp
@@ -212,28 +212,6 @@ inline shared_ptr<Node> handle_can_prove_helper(shared_ptr<Node> &typed_root, co
     return tree_constructor(typed_root, expr->value, typed_name, scope);
 }
 
-inline shared_ptr<Node> handle_can_prove(shared_ptr<Node> &root, const ExprPtr &expr, const std::string &name, VarScope &scope)
-{
-    const CanProve *op = expr->as<CanProve>();
-    assert(op); // We failed to identify the Expr properly.
-
-    std::string typed_name = make_new_unique_name();
-
-    shared_ptr<CFIR::CanProve> node = make_shared<CFIR::CanProve>(name, typed_name);
-    node = root->get_child(node);
-    assert(node);
-    typed_name = node->output_name;
-    shared_ptr<Node> typed_root = std::move(node);
-
-    return handle_can_prove_helper(typed_root, op, typed_name, scope);
-}
-
-inline shared_ptr<Node> handle_fold_helper(shared_ptr<Node> &typed_root, const Fold *expr, const std::string &typed_name, VarScope &scope)
-{
-    const std::string value = typed_name + "->value";
-    return tree_constructor(typed_root, expr->value, typed_name, scope);
-}
-
 inline shared_ptr<Node> handle_fold(shared_ptr<Node> &root, const ExprPtr &expr, const std::string &name, VarScope &scope)
 {
     const Fold *op = expr->as<Fold>();
@@ -268,22 +246,6 @@ inline shared_ptr<Node> handle_call_helper(shared_ptr<Node> &typed_root, const C
     }
 
     return cond_node;
-}
-
-inline shared_ptr<Node> handle_call(shared_ptr<Node> &root, const ExprPtr &expr, const std::string &name, VarScope &scope)
-{
-    const Call *op = expr->as<Call>();
-    assert(op); // We failed to identify the Expr properly.
-
-    std::string typed_name = make_new_unique_name();
-
-    shared_ptr<CFIR::Call> node = make_shared<CFIR::Call>(name, typed_name);
-    node = root->get_child(node);
-    assert(node);
-    typed_name = node->output_name;
-    shared_ptr<Node> typed_root = std::move(node);
-
-    return handle_call_helper(typed_root, op, typed_name, scope);
 }
 
 /*
@@ -376,12 +338,6 @@ shared_ptr<Node> tree_constructor(shared_ptr<Node> root, const ExprPtr &expr, co
         return handle_ramp(root, expr, name, scope);
     case NodeType::Broadcast:
         return handle_broadcast(root, expr, name, scope);
-    // case NodeType::CanProve:
-    //     return handle_can_prove(root, expr, name, scope);
-    // case NodeType::Fold:
-    //     return handle_fold(root, expr, name, scope);
-    // case NodeType::Call:
-    //     return handle_call(root, expr, name, scope);
     default:
         assert(false);
     }

--- a/MergeTool.cpp
+++ b/MergeTool.cpp
@@ -194,59 +194,14 @@ inline shared_ptr<Node> handle_constant_int(shared_ptr<Node> &root, const Consta
     std::string typed_name = make_new_unique_name();
 
     // Inserts the typecheck and fixes name if necessary
-    shared_ptr<CFIR::ConstantInt> imm_node = make_shared<CFIR::ConstantInt>(name, typed_name);
+    shared_ptr<CFIR::ConstantInt> imm_node = make_shared<CFIR::ConstantInt>(name, imm->value);
     imm_node = root->get_child(imm_node);
     assert(imm_node);
-    typed_name = imm_node->output_name;
-
-    const std::string condition = typed_name + "->value == " + std::to_string(imm->value);
-    shared_ptr<CFIR::Condition> cond_node = make_shared<CFIR::Condition>(condition);
-    // Inserts the condition after the typecheck
-    // It seems unlikely that this condition will already exist, but who knows? *shrug*
-    return imm_node->get_child(cond_node);
+    return imm_node;
 }
 
-inline shared_ptr<Node> handle_can_prove_helper(shared_ptr<Node> &typed_root, const CanProve *expr, const std::string &typed_name, VarScope &scope)
-{
-    const std::string value = typed_name + "->value";
-    return tree_constructor(typed_root, expr->value, typed_name, scope);
-}
 
-inline shared_ptr<Node> handle_fold(shared_ptr<Node> &root, const ExprPtr &expr, const std::string &name, VarScope &scope)
-{
-    const Fold *op = expr->as<Fold>();
-    assert(op); // We failed to identify the Expr properly.
 
-    std::string typed_name = make_new_unique_name();
-
-    shared_ptr<CFIR::Fold> node = make_shared<CFIR::Fold>(name, typed_name);
-    node = root->get_child(node);
-    assert(node);
-    typed_name = node->output_name;
-    shared_ptr<Node> typed_root = std::move(node);
-
-    return handle_fold_helper(typed_root, op, typed_name, scope);
-}
-
-inline shared_ptr<Node> handle_call_helper(shared_ptr<Node> &typed_root, const Call *expr, const std::string &typed_name, VarScope &scope)
-{
-    const std::string call_name = typed_name + "->name";
-    const std::string args_name = typed_name + "->args";
-    const std::string name = expr->name;
-    const std::vector<ExprPtr> args = expr->args;
-
-    const std::string condition = call_name + " == " + name;
-    shared_ptr<CFIR::Node> cond_node = make_shared<CFIR::Condition>(condition);
-
-    for (size_t i = 0; i < args.size(); ++i)
-    {
-        const ExprPtr arg = args[i];
-        const std::string arg_name = args_name + "[" + std::to_string(i) + "]";
-        cond_node = tree_constructor(cond_node, arg, arg_name, scope);
-    }
-
-    return cond_node;
-}
 
 /*
 TODOs:

--- a/halide-include/types.h
+++ b/halide-include/types.h
@@ -81,4 +81,15 @@ inline bool is_operand_no_overflow(const BinOp *bop) {
     return no_overflow(bop->a.type());
 }
 
+inline bool is_const_int(const Expr &expr, int64_t value) {
+    if (const UIntImm *as_uint = expr.as<UIntImm>()) {
+        return as_uint->value == (uint64_t)value;
+    } else if (const IntImm *as_int = expr.as<IntImm>()) {
+        return as_int->value == (int64_t)value;
+    } else if (const FloatImm *as_float = expr.as<FloatImm>()) {
+        return as_float->value == (double)value;
+    }
+    return false;
+}
+
 }  // namespace TypeCheck

--- a/include/CFIR.h
+++ b/include/CFIR.h
@@ -249,27 +249,6 @@ struct Ramp final : public TypeCheck<Ramp> {
     inline static const std::string type_name = "Ramp";
 };
 
-struct Call final : public TypeCheck<Call> {
-    Call(const std::string &_curr, const std::string &_out)
-        : TypeCheck(IRType::Call, _curr, _out) {
-    }
-    inline static const std::string type_name = "Call";
-};
-
-struct Fold final : public TypeCheck<Fold> {
-    Fold(const std::string &_curr, const std::string &_out)
-        : TypeCheck(IRType::Fold, _curr, _out) {
-    }
-    inline static const std::string type_name = "Fold";
-};
-
-struct CanProve final : public TypeCheck<CanProve> {
-    CanProve(const std::string &_curr, const std::string &_out)
-        : TypeCheck(IRType::CanProve, _curr, _out) {
-    }
-    inline static const std::string type_name = "CanProve";
-};
-
 struct ConstantInt final : public TypeCheck<ConstantInt> {
     ConstantInt(const std::string &_curr, const std::string &_out)
         : TypeCheck(IRType::ConstantInt, _curr, _out) {

--- a/include/CFIR.h
+++ b/include/CFIR.h
@@ -249,11 +249,14 @@ struct Ramp final : public TypeCheck<Ramp> {
     inline static const std::string type_name = "Ramp";
 };
 
-struct ConstantInt final : public TypeCheck<ConstantInt> {
-    ConstantInt(const std::string &_curr, const std::string &_out)
-        : TypeCheck(IRType::ConstantInt, _curr, _out) {
+struct ConstantInt final : public Node {
+    ConstantInt(const std::string &_name, int64_t _value)
+        : Node(IRType::ConstantInt), name(_name), value(_value) {
     }
-    inline static const std::string type_name = "ConstantInt";
+    const std::string name;
+    const int64_t value;
+    bool equal(const shared_ptr<Node> &other) const override;
+    void print(std::ostream &stream, std::string indent) const override;
 };
 
 struct Equality final : public Node {

--- a/include/ConstantCheck.h
+++ b/include/ConstantCheck.h
@@ -33,25 +33,25 @@ struct ConstantCheck final : public Visitor {
         expr->a->accept(this);
     }
 
-    void visit(const Select *expr) {
+    void visit(const Select *expr) override {
         expr->a->accept(this);
         expr->b->accept(this);
         expr->cond->accept(this);
     }
     
-    void visit(const Ramp *expr) {
+    void visit(const Ramp *expr) override {
         expr->base->accept(this);
         expr->lanes->accept(this);
         expr->stride->accept(this);
     }
-    void visit(const Broadcast *expr) {
+    void visit(const Broadcast *expr) override {
         expr->lanes->accept(this);
         expr->value->accept(this);
     }
-    void visit(const Fold *expr) {
+    void visit(const Fold *expr) override {
         expr->value->accept(this);
     }
-    void visit(const CanProve *expr) {
+    void visit(const CanProve *expr) override {
         expr->value->accept(this);
     }
 };

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char *argv[])
 {
     if (argc != 2)
     {
-        std::cout << "Usage: ./bin/Parser <input filename>\n";
+        std::cout << "Usage: ./main.out <input filename>\n";
         return 1;
     }
     std::string filename = argv[1];

--- a/src/CFIR.cpp
+++ b/src/CFIR.cpp
@@ -9,6 +9,22 @@ using std::vector;
 
 namespace CFIR {
 
+bool ConstantInt::equal(const shared_ptr<Node> &other) const {
+    if (const ConstantInt *other_ci = other->as<ConstantInt>(IRType::ConstantInt)) {
+        return (name == other_ci->name) && (value == other_ci->value);
+    } else {
+        return false;
+    }
+}
+
+void ConstantInt::print(std::ostream &stream, std::string indent) const {
+    stream << indent << "if (is_const_int(" << name << ", " << value << ")) {\n";
+    for (const auto &child : children) {
+        child->print(stream, indent + "  ");
+    }
+    stream << indent << "}\n";
+}
+
 bool Equality::equal(const shared_ptr<Node> &other) const {
     if (const Equality *other_equal = other->as<Equality>(IRType::Equality)) {
         return (name1 == other_equal->name1) && (name2 == other_equal->name2);

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,6 +1,7 @@
 #include "Parser.h"
 #include "ConstantCheck.h"
 
+#include <cstdint>
 #include <fstream>
 #include <stdio.h>
 #include <memory>
@@ -29,7 +30,7 @@ size_t get_filesize(const std::string &filename)
 
 void report_error(const char **cursor, const char *debug_info)
 {
-    printf(debug_info);
+    printf("%s", debug_info);
     printf("Parsing failed at %s\n", *cursor);
     abort();
 }
@@ -497,6 +498,7 @@ class Parser
             }
         }
         report_error("parse_type() found no type matches.");
+        return (NumericType)UINT16_MAX;
     }
 
     uint16_t parse_types()


### PR DESCRIPTION
Some CFIR structs were not needed, and I removed the corresponding handlers from MergeTool. Also fixed CodeGen for `ConstantInt`, it currently matches how Halide checks `IntLiteral`s in `IRMatch.h`.

Edit: also a few fly-by fixes that my compiler was complaining about.